### PR TITLE
Add automatic personal mod index

### DIFF
--- a/.github/workflows/mod-index-pages.yml
+++ b/.github/workflows/mod-index-pages.yml
@@ -1,0 +1,57 @@
+name: Build and publish mod index
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "*.zip"
+      - "scripts/build_mod_index.py"
+      - "site/**"
+      - ".github/workflows/mod-index-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build mod index
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          INDEX_DOWNLOAD_REF: main
+        run: python scripts/build_mod_index.py
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/MOD_INDEX.md
+++ b/MOD_INDEX.md
@@ -1,0 +1,53 @@
+# Personal Mod Index
+
+This repository publishes an automatic mod index for all installable `.zip` files stored in the repository root.
+
+The output follows the `schema_version: 1` feed shape used by `gen1recomp-mod-index`, while supporting this repository's monorepo layout: every ZIP is inspected directly and its internal `manifest.json` becomes one index entry.
+
+## Published files
+
+After GitHub Pages is enabled with **Source: GitHub Actions**, the workflow publishes:
+
+- a searchable web page at `https://faff0x.github.io/gen1recomp/`;
+- the machine-readable feed at `https://faff0x.github.io/gen1recomp/data/index.json`;
+- one generated Markdown description per mod under `data/mods/<author>@<id>/description.md`.
+
+## How it works
+
+`python scripts/build_mod_index.py`:
+
+1. finds every `.zip` in the repository root;
+2. requires exactly one `manifest.json` inside each archive;
+3. reads the mod ID, title, author, version, category, API, game version, permissions, dependencies and conflicts;
+4. creates a direct download URL for that exact ZIP;
+5. writes `site/data/index.json` and generated descriptions;
+6. fails the build when an archive is invalid, has no manifest, has a non-semver version, or duplicates another mod ID.
+
+The workflow runs after changes to ZIP files, the generator, the site, or the workflow itself.
+
+## Local validation
+
+From the repository root:
+
+```bash
+python scripts/build_mod_index.py
+python -m http.server -d site 8080
+```
+
+Then open `http://localhost:8080`.
+
+## Adding or updating a mod
+
+Upload the new ZIP to the repository root. Keep these requirements:
+
+- the archive contains exactly one `manifest.json`;
+- `manifest.json.id` uses only letters, numbers, `_` or `-`;
+- `manifest.json.version` is semantic versioning such as `1.2.0`;
+- IDs are unique across all ZIP files;
+- the ZIP remains directly installable by Gen 1 Recomp.
+
+No hand-written index entry is necessary. The next successful deployment rebuilds the complete feed.
+
+## Difference from the community index
+
+The community project normally keeps one metadata folder per mod and can track one GitHub Releases repository per entry. This repository stores many mod ZIPs together, so automatic release tracking is disabled per entry and each generated `downloadURL` points directly to the corresponding file on the `main` branch.

--- a/scripts/build_mod_index.py
+++ b/scripts/build_mod_index.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Build a Gen 1 Recomp-compatible index from mod ZIP files in the repo root."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE_DIR = ROOT / "site"
+DATA_DIR = SITE_DIR / "data"
+MODS_DIR = DATA_DIR / "mods"
+
+REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "FAFF0x/gen1recomp")
+DOWNLOAD_REF = os.environ.get("INDEX_DOWNLOAD_REF", "main")
+DEFAULT_AUTHOR = REPOSITORY.split("/", 1)[0]
+REPO_URL = f"https://github.com/{REPOSITORY}"
+
+ALLOWED_CATEGORIES = [
+    "GAMEPLAY", "CONTENT", "BALANCE", "ART", "AUDIO", "UI", "QOL",
+    "TRANSLATION", "TOTAL_CONVERSION", "LIBRARY", "TOOL", "OTHER",
+]
+ALLOWED_PROFILES = {"content", "overhaul", "total_conversion"}
+ALLOWED_PERMISSIONS = {"network", "filesystem", "engine_internals"}
+ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+].*)?$")
+
+CATEGORY_MAP = {
+    "QUEST": "CONTENT",
+    "STORY": "CONTENT",
+    "QUALITY_OF_LIFE": "QOL",
+    "QUALITY OF LIFE": "QOL",
+    "TOTAL CONVERSION": "TOTAL_CONVERSION",
+}
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_text_from_zip(archive: zipfile.ZipFile, path: str) -> str | None:
+    try:
+        return archive.read(path).decode("utf-8-sig").strip()
+    except (KeyError, UnicodeDecodeError):
+        return None
+
+
+def find_manifest(archive: zipfile.ZipFile) -> tuple[str, dict[str, Any]]:
+    candidates = [
+        name for name in archive.namelist()
+        if not name.endswith("/") and PurePosixPath(name).name.lower() == "manifest.json"
+    ]
+    if len(candidates) != 1:
+        raise ValueError(f"expected exactly one manifest.json, found {len(candidates)}")
+
+    manifest_path = candidates[0]
+    raw = read_text_from_zip(archive, manifest_path)
+    if raw is None:
+        raise ValueError("manifest.json is not valid UTF-8")
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid manifest.json: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest.json must contain a JSON object")
+    return manifest_path, manifest
+
+
+def normalize_categories(value: Any) -> list[str]:
+    values = value if isinstance(value, list) else [value]
+    result: list[str] = []
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        category = CATEGORY_MAP.get(item.strip().upper(), item.strip().upper())
+        if category in ALLOWED_CATEGORIES and category not in result:
+            result.append(category)
+    return result[:4] or ["OTHER"]
+
+
+def normalize_requirements(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        requirement: str | None = None
+        if isinstance(item, str):
+            requirement = item.strip()
+        elif isinstance(item, dict):
+            mod_id = item.get("id")
+            version = item.get("version") or item.get("constraint")
+            if isinstance(mod_id, str) and mod_id:
+                requirement = mod_id if not version else f"{mod_id}@{version}"
+        if requirement and requirement not in result:
+            result.append(requirement)
+    return result
+
+
+def one_line(value: Any, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    compact = " ".join(value.split())
+    return compact[:200] or fallback
+
+
+def optional_manifest_fields(manifest: dict[str, Any]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    api = manifest.get("api")
+    if isinstance(api, int) and 1 <= api <= 2:
+        output["api"] = api
+    game_version = manifest.get("game_version")
+    if isinstance(game_version, str) and game_version:
+        output["game_version"] = game_version[:64]
+    profile = manifest.get("profile")
+    if profile in ALLOWED_PROFILES:
+        output["profile"] = profile
+    if isinstance(manifest.get("affects_link"), bool):
+        output["affects_link"] = manifest["affects_link"]
+    if isinstance(manifest.get("experimental"), bool):
+        output["experimental"] = manifest["experimental"]
+    permissions = manifest.get("permissions")
+    if isinstance(permissions, list):
+        clean = [p for p in permissions if p in ALLOWED_PERMISSIONS]
+        if clean:
+            output["permissions"] = list(dict.fromkeys(clean))
+    dependencies = normalize_requirements(manifest.get("dependencies"))
+    conflicts = normalize_requirements(manifest.get("conflicts"))
+    if dependencies:
+        output["dependencies"] = dependencies
+    if conflicts:
+        output["conflicts"] = conflicts
+    license_name = manifest.get("license")
+    if isinstance(license_name, str) and license_name:
+        output["license"] = license_name[:64]
+    return output
+
+
+def build_description(
+    archive: zipfile.ZipFile,
+    manifest_path: str,
+    title: str,
+    summary: str,
+    download_url: str,
+) -> str:
+    parent = PurePosixPath(manifest_path).parent
+    for name in ("description.md", "README.md", "readme.md"):
+        text = read_text_from_zip(archive, str(parent / name))
+        if text:
+            return f"{text}\n\n---\n\n[Source repository]({REPO_URL}) · [Download ZIP]({download_url})\n"
+    return f"# {title}\n\n{summary}\n\n[Source repository]({REPO_URL}) · [Download ZIP]({download_url})\n"
+
+
+def build_entry(zip_path: Path) -> dict[str, Any]:
+    download_url = (
+        f"https://raw.githubusercontent.com/{REPOSITORY}/"
+        f"{quote(DOWNLOAD_REF, safe='')}/{quote(zip_path.name, safe='')}"
+    )
+    with zipfile.ZipFile(zip_path) as archive:
+        manifest_path, manifest = find_manifest(archive)
+        mod_id = manifest.get("id")
+        if not isinstance(mod_id, str) or not ID_RE.fullmatch(mod_id):
+            raise ValueError("manifest id is missing or invalid")
+        version = manifest.get("version")
+        if not isinstance(version, str) or not SEMVER_RE.fullmatch(version):
+            raise ValueError("manifest version is missing or is not semver")
+        title_value = manifest.get("name") or manifest.get("title") or mod_id.replace("_", " ").title()
+        title = one_line(title_value, mod_id)[:80]
+        author = one_line(manifest.get("author"), DEFAULT_AUTHOR)[:64]
+        summary = one_line(manifest.get("description"), f"{title} mod for Pokémon Gen 1 Recomp.")
+        folder = f"{DEFAULT_AUTHOR}@{mod_id}"
+        entry: dict[str, Any] = {
+            "folder": folder,
+            "id": mod_id,
+            "title": title,
+            "author": author,
+            "summary": summary,
+            "version": version,
+            "categories": normalize_categories(manifest.get("categories", manifest.get("category"))),
+            "repo": REPO_URL,
+            "downloadURL": download_url,
+            "automatic_version_check": False,
+            **optional_manifest_fields(manifest),
+            "thumbnail": None,
+            "description_url": f"data/mods/{folder}/description.md",
+            "latest": None,
+            "update_check": "off",
+        }
+        root_parts = PurePosixPath(manifest_path).parts
+        if len(root_parts) > 1:
+            install_folder = root_parts[0]
+            if install_folder != mod_id and ID_RE.fullmatch(install_folder):
+                entry["folderName"] = install_folder
+        description = build_description(archive, manifest_path, title, summary, download_url)
+
+    output_dir = MODS_DIR / folder
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "description.md").write_text(description, encoding="utf-8")
+    return entry
+
+
+def main() -> None:
+    zip_paths = sorted(ROOT.glob("*.zip"), key=lambda path: path.name.lower())
+    if not zip_paths:
+        fail(f"no mod ZIP files found in {ROOT}")
+    if MODS_DIR.exists():
+        shutil.rmtree(MODS_DIR)
+    MODS_DIR.mkdir(parents=True, exist_ok=True)
+
+    mods: list[dict[str, Any]] = []
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for zip_path in zip_paths:
+        try:
+            entry = build_entry(zip_path)
+            if entry["id"] in seen_ids:
+                raise ValueError(f"duplicate mod id {entry['id']!r}")
+            seen_ids.add(entry["id"])
+            mods.append(entry)
+            print(f"indexed {zip_path.name}: {entry['id']} {entry['version']}")
+        except (OSError, zipfile.BadZipFile, ValueError) as exc:
+            errors.append(f"{zip_path.name}: {exc}")
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        fail(f"index build failed for {len(errors)} archive(s)")
+
+    mods.sort(key=lambda mod: str(mod["title"]).casefold())
+    index = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "count": len(mods),
+        "categories": ALLOWED_CATEGORIES,
+        "mods": mods,
+    }
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    (DATA_DIR / "index.json").write_text(
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {DATA_DIR / 'index.json'} with {len(mods)} mods")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FAFF0x Gen 1 Recomp Mod Index</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, sans-serif; background: #10131a; color: #f4f6fb; }
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+    header { padding: 2rem 1rem 1rem; max-width: 1100px; margin: auto; }
+    h1 { margin: 0 0 .5rem; }
+    .controls { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: 1rem; }
+    input, select { padding: .75rem; border-radius: .6rem; border: 1px solid #485064; background: #1a2030; color: inherit; }
+    input { flex: 1 1 260px; }
+    main { max-width: 1100px; margin: auto; padding: 1rem; display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+    article { background: #181d29; border: 1px solid #30384a; border-radius: .85rem; padding: 1rem; display: flex; flex-direction: column; gap: .7rem; }
+    h2 { margin: 0; font-size: 1.15rem; }
+    p { margin: 0; color: #cbd2df; line-height: 1.45; }
+    .meta { color: #9fa9ba; font-size: .9rem; }
+    .tags { display: flex; gap: .4rem; flex-wrap: wrap; }
+    .tag { font-size: .75rem; border: 1px solid #53607a; border-radius: 999px; padding: .2rem .5rem; }
+    .links { margin-top: auto; display: flex; gap: .6rem; }
+    a { color: #93c5fd; }
+    .button { display: inline-block; padding: .55rem .8rem; background: #2563eb; color: white; text-decoration: none; border-radius: .5rem; font-weight: 650; }
+    #status { color: #aab3c2; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>FAFF0x Gen 1 Recomp Mod Index</h1>
+    <p id="status">Loading mods…</p>
+    <div class="controls">
+      <input id="search" type="search" placeholder="Search mods…" aria-label="Search mods">
+      <select id="category" aria-label="Filter by category"><option value="">All categories</option></select>
+    </div>
+  </header>
+  <main id="mods"></main>
+  <script>
+    const state = { mods: [], query: '', category: '' };
+    const list = document.querySelector('#mods');
+    const status = document.querySelector('#status');
+    const search = document.querySelector('#search');
+    const category = document.querySelector('#category');
+
+    function render() {
+      const query = state.query.toLowerCase();
+      const visible = state.mods.filter(mod => {
+        const haystack = `${mod.title} ${mod.id} ${mod.author} ${mod.summary}`.toLowerCase();
+        return (!query || haystack.includes(query)) && (!state.category || mod.categories.includes(state.category));
+      });
+      status.textContent = `${visible.length} of ${state.mods.length} mods`;
+      list.replaceChildren(...visible.map(mod => {
+        const card = document.createElement('article');
+        card.innerHTML = `
+          <h2>${escapeHtml(mod.title)} <span class="meta">v${escapeHtml(mod.version)}</span></h2>
+          <div class="meta">${escapeHtml(mod.author)} · ${escapeHtml(mod.id)}</div>
+          <p>${escapeHtml(mod.summary || '')}</p>
+          <div class="tags">${mod.categories.map(item => `<span class="tag">${escapeHtml(item)}</span>`).join('')}</div>
+          <div class="links">
+            <a class="button" href="${encodeURI(mod.downloadURL)}">Download ZIP</a>
+            <a href="${encodeURI(mod.repo)}">Source</a>
+          </div>`;
+        return card;
+      }));
+    }
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>'"]/g, char => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[char]));
+    }
+
+    search.addEventListener('input', event => { state.query = event.target.value; render(); });
+    category.addEventListener('change', event => { state.category = event.target.value; render(); });
+
+    fetch('./data/index.json')
+      .then(response => { if (!response.ok) throw new Error(`HTTP ${response.status}`); return response.json(); })
+      .then(index => {
+        state.mods = index.mods || [];
+        for (const item of index.categories || []) {
+          const option = document.createElement('option');
+          option.value = option.textContent = item;
+          category.append(option);
+        }
+        render();
+      })
+      .catch(error => { status.textContent = `Could not load index: ${error.message}`; });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a personal mod index inspired by `bryanthaboi/gen1recomp-mod-index`, adapted for this repository's monorepo layout.

### Included

- automatic inspection of every root-level mod ZIP;
- extraction of each internal `manifest.json`;
- generation of a schema-version-1 `site/data/index.json` feed;
- direct per-mod ZIP download URLs;
- searchable GitHub Pages catalog;
- GitHub Actions build and Pages deployment;
- setup and maintenance documentation in `MOD_INDEX.md`.

## Important setup after merge

In repository settings, open **Pages** and select **GitHub Actions** as the source. The published catalog will then be available at:

- `https://faff0x.github.io/gen1recomp/`
- `https://faff0x.github.io/gen1recomp/data/index.json`

## Validation behavior

The build fails when a ZIP is invalid, contains zero or multiple manifests, has an invalid ID/version, or duplicates another mod ID. This makes bad uploads visible immediately instead of silently publishing a broken entry.
